### PR TITLE
implemented quiet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Options:
   --only_created BOOLEAN   Only delete files you created?
   --sort [size|date|user]  Sort by 'size', 'date' or 'user'.
   --min_kb INTEGER         Minimum number of Kilobytes for file to qualify.
-  --quiet                  Deletes automatically the files (no prompt, so be really careful!)
+  --no-prompt                  Deletes automatically the files (no prompt, so be really careful!)
   --help                   Show this message and exit.
   
 </pre>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Options:
   --only_created BOOLEAN   Only delete files you created?
   --sort [size|date|user]  Sort by 'size', 'date' or 'user'.
   --min_kb INTEGER         Minimum number of Kilobytes for file to qualify.
+  --quiet                  Deletes automatically the files (no prompt, so be really careful!)
   --help                   Show this message and exit.
+  
 </pre>
 
 # In Action
@@ -49,4 +51,19 @@ DELETING FILES:
   Deleting Pasted image at 2016_08_07 10_11 PM.png (101.52 KB) ...  Deleted
 
 4 files deleted (463.00 KB)
+</pre>
+
+# Quiet Mode:
+<pre>
+python slackdeleter.py --token xoxp-SECRET-SECRET-SECRET-SECRET --days 31 --min_kb 1000 --only_created FALSE --sort size --quiet TRUE
+Querying Slack's Servers . . . . .
+Files:
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx     72.65 MB    	John Doe          	49 days ago
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx     60.28 MB    	Mark Appleseed 		49 days ago
+  
+9 files match your criteria. (289.06 MB)
+
+  Deleting xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (72.65 MB) ...  Deleted
+  Deleting xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (60.28 MB) ...  Deleted
+  
 </pre>

--- a/slackdeleter.py
+++ b/slackdeleter.py
@@ -107,7 +107,9 @@ def get_real_name(users, user_id):
 @click.option('--min_kb', default='1000', prompt='Minimum filesize to delete (in kilobytes)',
               help="Minimum number of Kilobytes for file to qualify.", type=click.INT)
 
-def query_slack(token, days, only_created, sort, min_kb):
+@click.option('--quiet', default=False, type=click.BOOL)
+
+def query_slack(token, days, only_created, sort, min_kb, quiet):
 
     print "Querying Slack's Servers",
 
@@ -151,7 +153,12 @@ def query_slack(token, days, only_created, sort, min_kb):
 
         print "\n%s files match your criteria. (%s)\n" % (len(delete_queue), human_size(total_bytes))
 
-        delete = click.confirm('Do you want to delete all of these files now?')
+        if quiet:
+            files_deleted, bytes_deleted = delete_files(delete_queue, token)
+            print '\n%s files deleted (%s)' % (files_deleted, human_size(bytes_deleted))
+            return
+        else:
+            delete = click.confirm('Do you want to delete all of these files now?')
 
         if delete:
             really = click.prompt("Type \"YES\" to really delete the files listed above")

--- a/slackdeleter.py
+++ b/slackdeleter.py
@@ -50,7 +50,7 @@ def delete_files(queue, token):
     bytes_deleted = 0
     files_deleted = 0
     for f in queue:
-        print "  Deleting %s (%s) ... " % (f['name'], human_size(f['size'])),
+        print "  Deleting %s (%s) ... " % (f['name'].encode("utf-8"), human_size(f['size'])),
 
         params['file'] = f['id']
         a = requests.get('https://slack.com/api/files.delete', params=params)
@@ -109,7 +109,7 @@ def get_real_name(users, user_id):
 
 @click.option('--no-prompt', default=False, type=click.BOOL)
 
-def query_slack(token, days, only_created, sort, min_kb, quiet):
+def query_slack(token, days, only_created, sort, min_kb, no_prompt):
 
     print "Querying Slack's Servers",
 
@@ -145,15 +145,15 @@ def query_slack(token, days, only_created, sort, min_kb, quiet):
         print "\nFiles:"
 
         for f in delete_queue:
-            real_name = get_real_name(users, f['user'])
+            real_name = get_real_name(users, f['user']).encode("utf-8")
 
-            print "  %s %s\t%s\t%s" % (f['name'].ljust(np + 4), human_size(f['size']).ljust(12),
+            print "  %s %s\t%s\t%s" % (f['name'].encode("utf-8").ljust(np + 4), human_size(f['size']).ljust(12),
                                        real_name.ljust(24),
                                        aft(f['created']))
 
         print "\n%s files match your criteria. (%s)\n" % (len(delete_queue), human_size(total_bytes))
 
-        if quiet:
+        if no_prompt:
             files_deleted, bytes_deleted = delete_files(delete_queue, token)
             print '\n%s files deleted (%s)' % (files_deleted, human_size(bytes_deleted))
             return

--- a/slackdeleter.py
+++ b/slackdeleter.py
@@ -107,7 +107,7 @@ def get_real_name(users, user_id):
 @click.option('--min_kb', default='1000', prompt='Minimum filesize to delete (in kilobytes)',
               help="Minimum number of Kilobytes for file to qualify.", type=click.INT)
 
-@click.option('--quiet', default=False, type=click.BOOL)
+@click.option('--no-prompt', default=False, type=click.BOOL)
 
 def query_slack(token, days, only_created, sort, min_kb, quiet):
 


### PR DESCRIPTION
Passing the --quiet TRUE parameter allows the slackdeleter to be put e.g. in a cron. Updated the README file as well